### PR TITLE
追加ユニットのホイールが Remap で割り当てたキー入力にならない不具合の修正

### DIFF
--- a/keyboards/tarohayashi/killerwhale/duo/keyboard.json
+++ b/keyboards/tarohayashi/killerwhale/duo/keyboard.json
@@ -39,7 +39,6 @@
       { "pin_a": "GP13", "pin_b": "GP14", "resolution": 2 },
       { "pin_a": "GP15", "pin_b": "GP17", "resolution": 2 },
       { "pin_a": "GP22", "pin_b": "GP26", "resolution": 2 },
-      { "pin_a": "GP20", "pin_b": "GP21", "resolution": 2 },
       { "pin_a": "GP20", "pin_b": "GP21", "resolution": 2 }
     ]
   },

--- a/keyboards/tarohayashi/killerwhale/duo/keymaps/default/keymap.c
+++ b/keyboards/tarohayashi/killerwhale/duo/keymaps/default/keymap.c
@@ -40,12 +40,10 @@ const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][2] = {
         ENCODER_CCW_CW(KC_3, KC_4),
         ENCODER_CCW_CW(KC_5, KC_6),
         ENCODER_CCW_CW(KC_7, KC_8),
-        ENCODER_CCW_CW(XXXXXXX, XXXXXXX),
         ENCODER_CCW_CW(KC_1, KC_2),
         ENCODER_CCW_CW(KC_3, KC_4),
         ENCODER_CCW_CW(KC_5, KC_6),
         ENCODER_CCW_CW(KC_7, KC_8),
-        ENCODER_CCW_CW(XXXXXXX, XXXXXXX)
     }
 };
 


### PR DESCRIPTION
現在配布されているファームウェアの最新バージョン 0.25.17 でホイールに対して行ったキーマッピングが意図しない挙動になっているように思われ、
修正方法が正しいかどうかわからないのですが、手元でひとまず意図通りの入力ができるようにできたので、一応プルリクエストを投げさせていただきます。

(もしより良い修正方法があれば遠慮なくクローズして別途修正いただいて大丈夫です)


## 問題の挙動の再現手順
- https://github.com/Taro-Hayashi/KillerWhale/releases/tag/0.25.17 から `tarohayashi_killerwhale_duo_via.uf2` をダウンロードし、Killer Whale に書き込む
- Remap にて左右のホイールに次の通りアローキーを割り当て
  - 左ホイール上/下にアローキーの ↑/↓ 
  - 右ホイール上/下にアローキーの ←/→
- 実際に入力されるもの
  - 左ホイール上: ❌️↑+Delete ? (※)
  - 左ホイール下: ⭕️↓
  - 右ホイール上: ❌️ホイール↑
  - 右ホイール下: ❌️ホイール↓

※アローキー↑を押してから Delete キーを押したのと同じ挙動になりました。
たとえば以下の `|` をカーソルだとすると
```
a
b|
```
この状態で左ホイールを上に転がすと以下のようになりました
```
a|b
```


　
## 自分でソースコードからビルドした場合の現象
- https://github.com/Taro-Hayashi/qmk_firmware/tree/tarohayashi (コミットハッシュ `6e037fb9025f0eaacb2c2809967b2a46da155b58`) に対して、次の変更を行った状態でビルドしました
  - `keyboards/tarohayashi/killerwhale/duo/keymaps/default/rules.mk` に `VIA_ENABLE = yes` を追加
- ビルドしたファームウェアを Killer Whale に書き込み
- Remap で左右のホイールに上記と同様に矢印キーを割り当て
- 実際に入力されるもの
  - 左ホイール上: ❌️アローキーの↑+Delete ? (※)
  - 左ホイール下: ⭕️アローキーの↓
  - 右ホイール上: ❌️7
  - 右ホイール下: ❌️8


　
## 上記に、さらにプルリクエストの修正を加えてビルドした場合
- 実際に入力されるもの
  - 左ホイール上: ⭕️アローキーの↑
  - 左ホイール下: ⭕️アローキーの↓
  - 右ホイール上: ⭕️アローキーの←
  - 右ホイール下: ⭕️アローキーの→
