### PR TITLE
rename layer_state_set_user to layer_state_set_kb

### DIFF
--- a/keyboards/tarohayashi/armors_v2/lib/add_rgblayers.c
+++ b/keyboards/tarohayashi/armors_v2/lib/add_rgblayers.c
@@ -26,12 +26,12 @@ void keyboard_post_init_kb(void) {
     rgblight_layers = my_rgb_layers;
 }
 
-layer_state_t layer_state_set_user(layer_state_t state) {
+layer_state_t layer_state_set_kb(layer_state_t state) {
     rgblight_set_layer_state(0, am_config.rgb_layers && layer_state_cmp(state, 0));
     rgblight_set_layer_state(1, am_config.rgb_layers && layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, am_config.rgb_layers && layer_state_cmp(state, 2));
     rgblight_set_layer_state(3, am_config.rgb_layers && layer_state_cmp(state, 3));
     rgblight_set_layer_state(4, am_config.rgb_layers && layer_state_cmp(state, 4));
     rgblight_set_layer_state(5, am_config.rgb_layers && layer_state_cmp(state, 5));
-    return state;
+    return layer_state_set_user(state);
 }

--- a/keyboards/tarohayashi/cannonball/lib/add_rgblayers.c
+++ b/keyboards/tarohayashi/cannonball/lib/add_rgblayers.c
@@ -26,12 +26,12 @@ void keyboard_post_init_kb(void) {
     rgblight_layers = my_rgb_layers;
 }
 
-layer_state_t layer_state_set_user(layer_state_t state) {
+layer_state_t layer_state_set_kb(layer_state_t state) {
     rgblight_set_layer_state(0, cb_config.rgb_layers && layer_state_cmp(state, 0));
     rgblight_set_layer_state(1, cb_config.rgb_layers && layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, cb_config.rgb_layers && layer_state_cmp(state, 2));
     rgblight_set_layer_state(3, cb_config.rgb_layers && layer_state_cmp(state, 3));
     rgblight_set_layer_state(4, cb_config.rgb_layers && layer_state_cmp(state, 4));
     rgblight_set_layer_state(5, cb_config.rgb_layers && layer_state_cmp(state, 5));
-    return state;
+    return layer_state_set_user(state);
 }

--- a/keyboards/tarohayashi/handyman/lib/add_rgblayers.c
+++ b/keyboards/tarohayashi/handyman/lib/add_rgblayers.c
@@ -26,12 +26,12 @@ void keyboard_post_init_kb(void) {
     rgblight_layers = my_rgb_layers;
 }
 
-layer_state_t layer_state_set_user(layer_state_t state) {
+layer_state_t layer_state_set_kb(layer_state_t state) {
     rgblight_set_layer_state(0, hm_config.rgb_layers && layer_state_cmp(state, 0));
     rgblight_set_layer_state(1, hm_config.rgb_layers && layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, hm_config.rgb_layers && layer_state_cmp(state, 2));
     rgblight_set_layer_state(3, hm_config.rgb_layers && layer_state_cmp(state, 3));
     rgblight_set_layer_state(4, hm_config.rgb_layers && layer_state_cmp(state, 4));
     rgblight_set_layer_state(5, hm_config.rgb_layers && layer_state_cmp(state, 5));
-    return state;
+    return layer_state_set_user(state);
 }

--- a/keyboards/tarohayashi/killerwhale/duo/lib/add_rgblayers.c
+++ b/keyboards/tarohayashi/killerwhale/duo/lib/add_rgblayers.c
@@ -36,7 +36,7 @@ void keyboard_post_init_kb(void) {
 }
 
 // 発光条件の設定
-layer_state_t layer_state_set_user(layer_state_t state) {
+layer_state_t layer_state_set_kb(layer_state_t state) {
     rgblight_set_layer_state(0, kw_config.rgb_layers && layer_state_cmp(state, 0));
     rgblight_set_layer_state(1, kw_config.rgb_layers && layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, kw_config.rgb_layers && layer_state_cmp(state, 2));
@@ -47,5 +47,5 @@ layer_state_t layer_state_set_user(layer_state_t state) {
     rgblight_set_layer_state(7, kw_config.rgb_layers && layer_state_cmp(state, 7));
     rgblight_set_layer_state(8, kw_config.rgb_layers && layer_state_cmp(state, 8));
     rgblight_set_layer_state(9, kw_config.rgb_layers && layer_state_cmp(state, 9));
-    return state;
+    return layer_state_set_user(state);
 }

--- a/keyboards/tarohayashi/killerwhale/solo/lib/add_rgblayers.c
+++ b/keyboards/tarohayashi/killerwhale/solo/lib/add_rgblayers.c
@@ -34,7 +34,7 @@ void keyboard_post_init_kb(void) {
     rgblight_layers = my_rgb_layers;
 }
 
-layer_state_t layer_state_set_user(layer_state_t state) {
+layer_state_t layer_state_set_kb(layer_state_t state) {
     rgblight_set_layer_state(0, kw_config.rgb_layers && layer_state_cmp(state, 0));
     rgblight_set_layer_state(1, kw_config.rgb_layers && layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, kw_config.rgb_layers && layer_state_cmp(state, 2));
@@ -45,5 +45,5 @@ layer_state_t layer_state_set_user(layer_state_t state) {
     rgblight_set_layer_state(7, kw_config.rgb_layers && layer_state_cmp(state, 7));
     rgblight_set_layer_state(8, kw_config.rgb_layers && layer_state_cmp(state, 8));
     rgblight_set_layer_state(9, kw_config.rgb_layers && layer_state_cmp(state, 9));
-    return state;
+    return layer_state_set_user(state);
 }

--- a/keyboards/tarohayashi/onthe15/lib/add_rgblayers.c
+++ b/keyboards/tarohayashi/onthe15/lib/add_rgblayers.c
@@ -26,12 +26,12 @@ void keyboard_post_init_kb(void) {
     rgblight_layers = my_rgb_layers;
 }
 
-layer_state_t layer_state_set_user(layer_state_t state) {
+layer_state_t layer_state_set_kb(layer_state_t state) {
     rgblight_set_layer_state(0, ot15_config.rgb_layers && layer_state_cmp(state, 0));
     rgblight_set_layer_state(1, ot15_config.rgb_layers && layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, ot15_config.rgb_layers && layer_state_cmp(state, 2));
     rgblight_set_layer_state(3, ot15_config.rgb_layers && layer_state_cmp(state, 3));
     rgblight_set_layer_state(4, ot15_config.rgb_layers && layer_state_cmp(state, 4));
     rgblight_set_layer_state(5, ot15_config.rgb_layers && layer_state_cmp(state, 5));
-    return state;
+    return layer_state_set_user(state);
 }

--- a/keyboards/tarohayashi/onthe17/lib/add_rgblayers.c
+++ b/keyboards/tarohayashi/onthe17/lib/add_rgblayers.c
@@ -26,12 +26,12 @@ void keyboard_post_init_kb(void) {
     rgblight_layers = my_rgb_layers;
 }
 
-layer_state_t layer_state_set_user(layer_state_t state) {
+layer_state_t layer_state_set_kb(layer_state_t state) {
     rgblight_set_layer_state(0, ot17_config.rgb_layers && layer_state_cmp(state, 0));
     rgblight_set_layer_state(1, ot17_config.rgb_layers && layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, ot17_config.rgb_layers && layer_state_cmp(state, 2));
     rgblight_set_layer_state(3, ot17_config.rgb_layers && layer_state_cmp(state, 3));
     rgblight_set_layer_state(4, ot17_config.rgb_layers && layer_state_cmp(state, 4));
     rgblight_set_layer_state(5, ot17_config.rgb_layers && layer_state_cmp(state, 5));
-    return state;
+    return layer_state_set_user(state);
 }

--- a/keyboards/tarohayashi/popntop/leftconnected/lib/add_rgblayers.c
+++ b/keyboards/tarohayashi/popntop/leftconnected/lib/add_rgblayers.c
@@ -26,12 +26,12 @@ void keyboard_post_init_kb(void) {
     rgblight_layers = my_rgb_layers;
 }
 
-layer_state_t layer_state_set_user(layer_state_t state) {
+layer_state_t layer_state_set_kb(layer_state_t state) {
     rgblight_set_layer_state(0, pt_config.rgb_layers && layer_state_cmp(state, 0));
     rgblight_set_layer_state(1, pt_config.rgb_layers && layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, pt_config.rgb_layers && layer_state_cmp(state, 2));
     rgblight_set_layer_state(3, pt_config.rgb_layers && layer_state_cmp(state, 3));
     rgblight_set_layer_state(4, pt_config.rgb_layers && layer_state_cmp(state, 4));
     rgblight_set_layer_state(5, pt_config.rgb_layers && layer_state_cmp(state, 5));
-    return state;
+    return layer_state_set_user(state);
 }

--- a/keyboards/tarohayashi/popntop/rightconnected/lib/add_rgblayers.c
+++ b/keyboards/tarohayashi/popntop/rightconnected/lib/add_rgblayers.c
@@ -26,12 +26,12 @@ void keyboard_post_init_kb(void) {
     rgblight_layers = my_rgb_layers;
 }
 
-layer_state_t layer_state_set_user(layer_state_t state) {
+layer_state_t layer_state_set_kb(layer_state_t state) {
     rgblight_set_layer_state(0, pt_config.rgb_layers && layer_state_cmp(state, 0));
     rgblight_set_layer_state(1, pt_config.rgb_layers && layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, pt_config.rgb_layers && layer_state_cmp(state, 2));
     rgblight_set_layer_state(3, pt_config.rgb_layers && layer_state_cmp(state, 3));
     rgblight_set_layer_state(4, pt_config.rgb_layers && layer_state_cmp(state, 4));
     rgblight_set_layer_state(5, pt_config.rgb_layers && layer_state_cmp(state, 5));
-    return state;
+    return layer_state_set_user(state);
 }

--- a/keyboards/tarohayashi/popntop_np/leftconnected/lib/add_rgblayers.c
+++ b/keyboards/tarohayashi/popntop_np/leftconnected/lib/add_rgblayers.c
@@ -26,12 +26,12 @@ void keyboard_post_init_kb(void) {
     rgblight_layers = my_rgb_layers;
 }
 
-layer_state_t layer_state_set_user(layer_state_t state) {
+layer_state_t layer_state_set_kb(layer_state_t state) {
     rgblight_set_layer_state(0, ptnp_config.rgb_layers && layer_state_cmp(state, 0));
     rgblight_set_layer_state(1, ptnp_config.rgb_layers && layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, ptnp_config.rgb_layers && layer_state_cmp(state, 2));
     rgblight_set_layer_state(3, ptnp_config.rgb_layers && layer_state_cmp(state, 3));
     rgblight_set_layer_state(4, ptnp_config.rgb_layers && layer_state_cmp(state, 4));
     rgblight_set_layer_state(5, ptnp_config.rgb_layers && layer_state_cmp(state, 5));
-    return state;
+    return layer_state_set_user(state);
 }

--- a/keyboards/tarohayashi/popntop_np/rightconnected/lib/add_rgblayers.c
+++ b/keyboards/tarohayashi/popntop_np/rightconnected/lib/add_rgblayers.c
@@ -26,12 +26,12 @@ void keyboard_post_init_kb(void) {
     rgblight_layers = my_rgb_layers;
 }
 
-layer_state_t layer_state_set_user(layer_state_t state) {
+layer_state_t layer_state_set_kb(layer_state_t state) {
     rgblight_set_layer_state(0, ptnp_config.rgb_layers && layer_state_cmp(state, 0));
     rgblight_set_layer_state(1, ptnp_config.rgb_layers && layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, ptnp_config.rgb_layers && layer_state_cmp(state, 2));
     rgblight_set_layer_state(3, ptnp_config.rgb_layers && layer_state_cmp(state, 3));
     rgblight_set_layer_state(4, ptnp_config.rgb_layers && layer_state_cmp(state, 4));
     rgblight_set_layer_state(5, ptnp_config.rgb_layers && layer_state_cmp(state, 5));
-    return state;
+    return layer_state_set_user(state);
 }

--- a/keyboards/tarohayashi/shotgun_cp/lib/add_rgblayers.c
+++ b/keyboards/tarohayashi/shotgun_cp/lib/add_rgblayers.c
@@ -26,12 +26,12 @@ void keyboard_post_init_kb(void) {
     rgblight_layers = my_rgb_layers;
 }
 
-layer_state_t layer_state_set_user(layer_state_t state) {
+layer_state_t layer_state_set_kb(layer_state_t state) {
     rgblight_set_layer_state(0, sgcp_config.rgb_layers && layer_state_cmp(state, 0));
     rgblight_set_layer_state(1, sgcp_config.rgb_layers && layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, sgcp_config.rgb_layers && layer_state_cmp(state, 2));
     rgblight_set_layer_state(3, sgcp_config.rgb_layers && layer_state_cmp(state, 3));
     rgblight_set_layer_state(4, sgcp_config.rgb_layers && layer_state_cmp(state, 4));
     rgblight_set_layer_state(5, sgcp_config.rgb_layers && layer_state_cmp(state, 5));
-    return state;
+    return layer_state_set_user(state);
 }

--- a/keyboards/tarohayashi/shotgun_v2/lib/add_rgblayers.c
+++ b/keyboards/tarohayashi/shotgun_v2/lib/add_rgblayers.c
@@ -26,12 +26,12 @@ void keyboard_post_init_kb(void) {
     rgblight_layers = my_rgb_layers;
 }
 
-layer_state_t layer_state_set_user(layer_state_t state) {
+layer_state_t layer_state_set_kb(layer_state_t state) {
     rgblight_set_layer_state(0, sg_config.rgb_layers && layer_state_cmp(state, 0));
     rgblight_set_layer_state(1, sg_config.rgb_layers && layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, sg_config.rgb_layers && layer_state_cmp(state, 2));
     rgblight_set_layer_state(3, sg_config.rgb_layers && layer_state_cmp(state, 3));
     rgblight_set_layer_state(4, sg_config.rgb_layers && layer_state_cmp(state, 4));
     rgblight_set_layer_state(5, sg_config.rgb_layers && layer_state_cmp(state, 5));
-    return state;
+    return layer_state_set_user(state);
 }

--- a/keyboards/tarohayashi/undertow/lib/add_rgblayers.c
+++ b/keyboards/tarohayashi/undertow/lib/add_rgblayers.c
@@ -34,7 +34,7 @@ void keyboard_post_init_kb(void) {
     rgblight_layers = my_rgb_layers;
 }
 
-layer_state_t layer_state_set_user(layer_state_t state) {
+layer_state_t layer_state_set_kb(layer_state_t state) {
     rgblight_set_layer_state(0, get_rgblayers() && layer_state_cmp(state, 0));
     rgblight_set_layer_state(1, get_rgblayers() && layer_state_cmp(state, 1));
     rgblight_set_layer_state(2, get_rgblayers() && layer_state_cmp(state, 2));
@@ -45,5 +45,5 @@ layer_state_t layer_state_set_user(layer_state_t state) {
     rgblight_set_layer_state(7, get_rgblayers() && layer_state_cmp(state, 7));
     rgblight_set_layer_state(8, get_rgblayers() && layer_state_cmp(state, 8));
     rgblight_set_layer_state(9, get_rgblayers() && layer_state_cmp(state, 9));
-    return state;
+    return layer_state_set_user(state);
 }


### PR DESCRIPTION
以下のように `layer_state_set_user` を user 側の `keymap.c` で利用したいため、 `layer_state_set_kb` を利用するように修正します。

```c
layer_state_t layer_state_set_user(layer_state_t state) {
    state = update_tri_layer_state(state, ONOFF, OFFON, ONON);
    state = update_tri_layer_state(state, LOWER, UPPER, ADJUST);
    return state;
}
```

KillerWhale でしか動作確認できていませんが、他のキーボードも同様かと思ったので一緒に修正しています。